### PR TITLE
feat: 사용자 로그인 처리 기능 추가 및 Jwt기반 인증/인가 세팅

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -38,11 +38,18 @@ services:
             dockerfile: Dockerfile
         environment:
             - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-default}
+            # Database configuration
             - DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
-            - REDIS_URL=redis://redis:6379
             - POSTGRES_USER=${POSTGRES_USER}
             - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
             - POSTGRES_DB=${POSTGRES_DB}
+            # Redis configuration
+            - REDIS_URL=redis://redis:6379
+            # JWT Secret Key
+            - JWT_SECRET_KEY=${JWT_SECRET}
+            # Kakao API Key
+            - KAKAO_CLIENT_ID=${KAKAO_CLIENT_ID}
+            - KAKAO_REDIRECT_URI=${KAKAO_REDIRECT_URI}
         ports:
             - '${WEB_PORT:-8000}:8080'
         depends_on:

--- a/src/main/kotlin/com/zzan/zzan/api/liquor/LiquorController.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/liquor/LiquorController.kt
@@ -5,16 +5,16 @@ import com.zzan.zzan.common.response.ApiResponse
 import com.zzan.zzan.liquor.query.handler.LiquorQueryService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class LiquorController (
+@RequestMapping("/liquor")
+class LiquorController(
     private val liquorQueryService: LiquorQueryService,
-){
-    @GetMapping("/liquors/{id}")
+) {
+    @GetMapping("/{id}")
     fun getLiquorById(@PathVariable id: String): ApiResponse<LiquorDetailResponse> {
-        return ApiResponse.ok(
-            liquorQueryService.getLiquorById(id)
-        )
+        return ApiResponse.ok(liquorQueryService.getLiquorById(id))
     }
 }

--- a/src/main/kotlin/com/zzan/zzan/api/place/PlaceController.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/place/PlaceController.kt
@@ -5,13 +5,15 @@ import com.zzan.zzan.api.place.dto.ViewBoxRequest
 import com.zzan.zzan.common.response.ApiResponse
 import com.zzan.zzan.place.query.handler.PlaceQueryService
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
+@RequestMapping("/place")
 class PlaceController(
     private val placeQueryService: PlaceQueryService
 ) {
-    @GetMapping("/places")
+    @GetMapping("/list")
     fun getPlaces(request: ViewBoxRequest): ApiResponse<List<PlaceResponse>> {
         val viewBox = request.toViewBox()
         return ApiResponse.ok(placeQueryService.getPlacesInViewBox(viewBox))

--- a/src/main/kotlin/com/zzan/zzan/api/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/security/config/SecurityConfig.kt
@@ -1,4 +1,4 @@
-package com.zzan.zzan.api.config
+package com.zzan.zzan.api.security.config
 
 import com.zzan.zzan.api.security.filter.JwtAuthenticationFilter
 import org.springframework.context.annotation.Bean
@@ -8,7 +8,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
-
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/kotlin/com/zzan/zzan/api/user/AuthController.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/user/AuthController.kt
@@ -1,0 +1,27 @@
+package com.zzan.zzan.api.user
+
+import com.zzan.zzan.api.user.dto.LoginResponse
+import com.zzan.zzan.api.user.dto.LoginUrl
+import com.zzan.zzan.common.response.ApiResponse
+import com.zzan.zzan.user.query.handler.AuthService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/auth")
+class AuthController(
+    private val authService: AuthService
+) {
+
+    @GetMapping("/kakao/login-url")
+    fun getLoginUrl(): ApiResponse<LoginUrl> {
+        return ApiResponse.ok(authService.getKakaoLoginUrl());
+    }
+
+    @GetMapping("/kakao/callback")
+    fun kakaoCallback(@RequestParam code: String): ApiResponse<LoginResponse> {
+        return ApiResponse.ok(authService.handleKakaoCallback(code))
+    }
+}

--- a/src/main/kotlin/com/zzan/zzan/api/user/dto/LoginResponse.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/user/dto/LoginResponse.kt
@@ -1,0 +1,6 @@
+package com.zzan.zzan.api.user.dto
+
+data class LoginResponse(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/src/main/kotlin/com/zzan/zzan/api/user/dto/LoginUrl.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/user/dto/LoginUrl.kt
@@ -1,0 +1,5 @@
+package com.zzan.zzan.api.user.dto
+
+data class LoginUrl(
+    val url: String
+)

--- a/src/main/kotlin/com/zzan/zzan/common/client/KakaoApiClient.kt
+++ b/src/main/kotlin/com/zzan/zzan/common/client/KakaoApiClient.kt
@@ -4,33 +4,38 @@ import com.zzan.zzan.common.client.dto.KakaoTokenResponse
 import com.zzan.zzan.common.client.dto.KakaoUserResponse
 import com.zzan.zzan.common.config.properties.KakaoProperties
 import com.zzan.zzan.common.exception.CustomException
+import mu.KLogging
 import org.springframework.http.*
 import org.springframework.stereotype.Component
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.RestClientException
 import org.springframework.web.client.RestTemplate
 
 @Component
 class KakaoApiClient(
     private val kakaoProperties: KakaoProperties
-) {
+) : KLogging() {
     private val restTemplate = RestTemplate()
 
     fun getAccessToken(code: String): String {
-        return restTemplate.postForEntity(
-            KAKAO_TOKEN_URL,
-            createTokenRequest(code),
-            KakaoTokenResponse::class.java
-        ).body?.accessToken
-            ?: throw CustomException(HttpStatus.UNAUTHORIZED, "카카오 액세스 토큰 획득에 실패했습니다")
+        return call("카카오 액세스 토큰 획득에 실패했습니다") {
+            restTemplate.postForEntity(
+                KAKAO_TOKEN_URL,
+                createTokenRequest(code),
+                KakaoTokenResponse::class.java
+            ).body?.accessToken
+        }
     }
 
     fun getUserInfo(kakaoAccessToken: String): KakaoUserResponse {
-        return restTemplate.exchange(
-            KAKAO_USER_INFO_URL,
-            HttpMethod.GET,
-            createUserInfoRequest(kakaoAccessToken),
-            KakaoUserResponse::class.java
-        ).body
-            ?: throw CustomException(HttpStatus.BAD_REQUEST, "카카오 사용자 정보를 가져올 수 없습니다")
+        return call("카카오 사용자 정보를 가져올 수 없습니다") {
+            restTemplate.exchange(
+                KAKAO_USER_INFO_URL,
+                HttpMethod.GET,
+                createUserInfoRequest(kakaoAccessToken),
+                KakaoUserResponse::class.java
+            ).body
+        }
     }
 
     fun getLoginUrl(): String {
@@ -46,14 +51,12 @@ class KakaoApiClient(
         val headers = HttpHeaders().apply {
             contentType = MediaType.APPLICATION_FORM_URLENCODED
         }
-
         val body = buildString {
             append("grant_type=authorization_code")
             append("&client_id=${kakaoProperties.clientId}")
             append("&redirect_uri=${kakaoProperties.redirectUri}")
             append("&code=$code")
         }
-
         return HttpEntity(body, headers)
     }
 
@@ -62,6 +65,19 @@ class KakaoApiClient(
             set("Authorization", "Bearer $accessToken")
         }
         return HttpEntity(headers)
+    }
+
+    // API 호출 및 예외 처리 공통 로직
+    private fun <T> call(errorMessage: String, block: () -> T?): T {
+        return try {
+            block() ?: throw CustomException(HttpStatus.UNAUTHORIZED, errorMessage)
+        } catch (ex: HttpClientErrorException) {
+            logger.error { "Kakao API Error: ${ex.statusCode} - ${ex.responseBodyAsString}" }
+            throw CustomException(HttpStatus.UNAUTHORIZED, errorMessage)
+        } catch (ex: RestClientException) {
+            logger.error { "Kakao API RestClientException: ${ex.message}" }
+            throw CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "외부 서버 통신 오류: ${ex.message}")
+        }
     }
 
     companion object {

--- a/src/main/kotlin/com/zzan/zzan/common/client/KakaoApiClient.kt
+++ b/src/main/kotlin/com/zzan/zzan/common/client/KakaoApiClient.kt
@@ -1,0 +1,72 @@
+package com.zzan.zzan.common.client
+
+import com.zzan.zzan.common.client.dto.KakaoTokenResponse
+import com.zzan.zzan.common.client.dto.KakaoUserResponse
+import com.zzan.zzan.common.config.properties.KakaoProperties
+import com.zzan.zzan.common.exception.CustomException
+import org.springframework.http.*
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+
+@Component
+class KakaoApiClient(
+    private val kakaoProperties: KakaoProperties
+) {
+    private val restTemplate = RestTemplate()
+
+    fun getAccessToken(code: String): String {
+        return restTemplate.postForEntity(
+            KAKAO_TOKEN_URL,
+            createTokenRequest(code),
+            KakaoTokenResponse::class.java
+        ).body?.accessToken
+            ?: throw CustomException(HttpStatus.UNAUTHORIZED, "카카오 액세스 토큰 획득에 실패했습니다")
+    }
+
+    fun getUserInfo(kakaoAccessToken: String): KakaoUserResponse {
+        return restTemplate.exchange(
+            KAKAO_USER_INFO_URL,
+            HttpMethod.GET,
+            createUserInfoRequest(kakaoAccessToken),
+            KakaoUserResponse::class.java
+        ).body
+            ?: throw CustomException(HttpStatus.BAD_REQUEST, "카카오 사용자 정보를 가져올 수 없습니다")
+    }
+
+    fun getLoginUrl(): String {
+        return buildString {
+            append(KAKAO_AUTH_URL)
+            append("?client_id=${kakaoProperties.clientId}")
+            append("&redirect_uri=${kakaoProperties.redirectUri}")
+            append("&response_type=code")
+        }
+    }
+
+    private fun createTokenRequest(code: String): HttpEntity<String> {
+        val headers = HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_FORM_URLENCODED
+        }
+
+        val body = buildString {
+            append("grant_type=authorization_code")
+            append("&client_id=${kakaoProperties.clientId}")
+            append("&redirect_uri=${kakaoProperties.redirectUri}")
+            append("&code=$code")
+        }
+
+        return HttpEntity(body, headers)
+    }
+
+    private fun createUserInfoRequest(accessToken: String): HttpEntity<String> {
+        val headers = HttpHeaders().apply {
+            set("Authorization", "Bearer $accessToken")
+        }
+        return HttpEntity(headers)
+    }
+
+    companion object {
+        private const val KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token"
+        private const val KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me"
+        private const val KAKAO_AUTH_URL = "https://kauth.kakao.com/oauth/authorize"
+    }
+}

--- a/src/main/kotlin/com/zzan/zzan/common/client/dto/KakaoTokenResponse.kt
+++ b/src/main/kotlin/com/zzan/zzan/common/client/dto/KakaoTokenResponse.kt
@@ -1,0 +1,17 @@
+package com.zzan.zzan.common.client.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class KakaoTokenResponse(
+    @JsonProperty("access_token")
+    val accessToken: String,
+
+    @JsonProperty("token_type")
+    val tokenType: String,
+
+    @JsonProperty("refresh_token")
+    val refreshToken: String,
+
+    @JsonProperty("expires_in")
+    val expiresIn: Int
+)

--- a/src/main/kotlin/com/zzan/zzan/common/client/dto/KakaoUserResponse.kt
+++ b/src/main/kotlin/com/zzan/zzan/common/client/dto/KakaoUserResponse.kt
@@ -1,0 +1,24 @@
+package com.zzan.zzan.common.client.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class KakaoUserResponse(
+    val id: Long,
+
+    @JsonProperty("connected_at")
+    val connectedAt: String?,
+
+    @JsonProperty("kakao_account")
+    val kakaoAccount: KakaoAccount
+) {
+    data class KakaoAccount(
+        val profile: Profile
+    )
+
+    data class Profile(
+        val nickname: String,
+
+        @JsonProperty("profile_image_url")
+        val profileImageUrl: String? = null
+    )
+}

--- a/src/main/kotlin/com/zzan/zzan/common/config/CacheConfig.kt
+++ b/src/main/kotlin/com/zzan/zzan/common/config/CacheConfig.kt
@@ -32,8 +32,6 @@ class CacheConfig {
                     GenericJackson2JsonRedisSerializer(redisObjectMapper)
                 )
             )
-            .disableCachingNullValues()
-
         return RedisCacheManager.builder(redisConnectionFactory)
             .cacheDefaults(cacheConfig)
             .build()

--- a/src/main/kotlin/com/zzan/zzan/common/config/JwtConfig.kt
+++ b/src/main/kotlin/com/zzan/zzan/common/config/JwtConfig.kt
@@ -1,0 +1,32 @@
+package com.zzan.zzan.common.config
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret
+import com.nimbusds.jose.proc.SecurityContext
+import com.zzan.zzan.common.config.properties.JwtProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.JwtEncoder
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder
+import javax.crypto.spec.SecretKeySpec
+
+@Configuration
+class JwtConfig(
+    private val jwtProperties: JwtProperties
+) {
+
+    @Bean
+    fun jwtEncoder(): JwtEncoder {
+        val secret = SecretKeySpec(jwtProperties.secretKey.toByteArray(), "HmacSHA256")
+        val immutableSecret = ImmutableSecret<SecurityContext>(secret)
+        return NimbusJwtEncoder(immutableSecret)
+    }
+
+    @Bean
+    fun jwtDecoder(): JwtDecoder {
+        val secret = SecretKeySpec(jwtProperties.secretKey.toByteArray(), "HmacSHA256")
+        return NimbusJwtDecoder.withSecretKey(secret).macAlgorithm(MacAlgorithm.HS256).build()
+    }
+}

--- a/src/main/kotlin/com/zzan/zzan/common/config/properties/JwtProperties.kt
+++ b/src/main/kotlin/com/zzan/zzan/common/config/properties/JwtProperties.kt
@@ -1,0 +1,12 @@
+package com.zzan.zzan.common.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "jwt")
+class JwtProperties {
+    lateinit var secretKey: String
+    val accessTokenValiditySeconds: Long = 3600 // 1 hour
+    val refreshTokenValiditySeconds: Long = 30 * 24 * 60 * 60 // 30 days
+}

--- a/src/main/kotlin/com/zzan/zzan/common/config/properties/KakaoProperties.kt
+++ b/src/main/kotlin/com/zzan/zzan/common/config/properties/KakaoProperties.kt
@@ -1,0 +1,11 @@
+package com.zzan.zzan.common.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "kakao")
+class KakaoProperties {
+    lateinit var clientId: String
+    lateinit var redirectUri: String
+}

--- a/src/main/kotlin/com/zzan/zzan/common/util/JwtUtil.kt
+++ b/src/main/kotlin/com/zzan/zzan/common/util/JwtUtil.kt
@@ -1,0 +1,87 @@
+package com.zzan.zzan.common.util
+
+import com.zzan.zzan.common.config.properties.JwtProperties
+import com.zzan.zzan.common.exception.CustomException
+import org.springframework.http.HttpStatus
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm
+import org.springframework.security.oauth2.jwt.*
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+@Component
+class JwtUtil(
+    private val jwtProperties: JwtProperties,
+    private val jwtEncoder: JwtEncoder,
+    private val jwtDecoder: JwtDecoder
+) {
+
+    enum class Token(val type: String) {
+        Access("access"),
+        Refresh("refresh")
+    }
+
+    private fun createToken(userId: String, validitySeconds: Long, token: Token): String {
+        val now = Instant.now()
+        val expiry = now.plusSeconds(validitySeconds)
+
+        val claims = JwtClaimsSet.builder()
+            .subject(userId)
+            .issuedAt(now)
+            .expiresAt(expiry)
+            .claim("type", token.type)
+            .build()
+
+        val headers = JwsHeader.with(MacAlgorithm.HS256).build()
+        return jwtEncoder.encode(JwtEncoderParameters.from(headers, claims)).tokenValue
+    }
+
+    fun createAccessToken(userId: String): String {
+        return createToken(userId, jwtProperties.accessTokenValiditySeconds, Token.Access)
+    }
+
+    fun createRefreshToken(userId: String): String {
+        return createToken(userId, jwtProperties.refreshTokenValiditySeconds, Token.Refresh)
+    }
+
+    fun validateToken(token: String): Boolean {
+        return try {
+            jwtDecoder.decode(token)
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    fun getUserIdFromToken(token: String): String {
+        return try {
+            jwtDecoder.decode(token).subject
+        } catch (e: Exception) {
+            throw CustomException(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다")
+        }
+    }
+
+    fun getTokenType(token: String): String {
+        return try {
+            jwtDecoder.decode(token).getClaimAsString("type")
+        } catch (e: Exception) {
+            throw CustomException(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다")
+        }
+    }
+
+    fun isAccessToken(token: String): Boolean {
+        return getTokenType(token) == Token.Access.type
+    }
+
+    fun isRefreshToken(token: String): Boolean {
+        return getTokenType(token) == Token.Refresh.type
+    }
+
+    fun isTokenExpired(token: String): Boolean {
+        return try {
+            val jwt = jwtDecoder.decode(token)
+            jwt.expiresAt?.isBefore(Instant.now()) ?: true
+        } catch (e: Exception) {
+            true
+        }
+    }
+}

--- a/src/main/kotlin/com/zzan/zzan/user/command/application/UserCommandService.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/command/application/UserCommandService.kt
@@ -1,0 +1,7 @@
+package com.zzan.zzan.user.command.application
+
+import com.zzan.zzan.user.command.domain.User
+
+interface UserCommandService {
+    fun createUser(user: User): String
+}

--- a/src/main/kotlin/com/zzan/zzan/user/command/application/UserCommandServiceImpl.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/command/application/UserCommandServiceImpl.kt
@@ -1,0 +1,17 @@
+package com.zzan.zzan.user.command.application
+
+import com.zzan.zzan.user.command.domain.User
+import com.zzan.zzan.user.command.infrastructure.UserCommandRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class UserCommandServiceImpl(
+    private val userRepository: UserCommandRepository
+) : UserCommandService {
+    override fun createUser(user: User): String {
+        val savedUser = userRepository.save(user)
+        return savedUser.id
+    }
+}

--- a/src/main/kotlin/com/zzan/zzan/user/command/application/UserCommandServiceImpl.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/command/application/UserCommandServiceImpl.kt
@@ -2,6 +2,7 @@ package com.zzan.zzan.user.command.application
 
 import com.zzan.zzan.user.command.domain.User
 import com.zzan.zzan.user.command.infrastructure.UserCommandRepository
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -10,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional
 class UserCommandServiceImpl(
     private val userRepository: UserCommandRepository
 ) : UserCommandService {
+
+    @CacheEvict(value = ["userIdByKakaoId"], key = "#user.kakaoId")
     override fun createUser(user: User): String {
         val savedUser = userRepository.save(user)
         return savedUser.id

--- a/src/main/kotlin/com/zzan/zzan/user/command/domain/User.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/command/domain/User.kt
@@ -1,6 +1,7 @@
 package com.zzan.zzan.user.command.domain
 
 import com.github.f4b6a3.ulid.UlidCreator
+import com.zzan.zzan.common.client.dto.KakaoUserResponse
 import jakarta.persistence.*
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
@@ -27,8 +28,18 @@ class User(
 
     @CreatedDate
     @Column(name = "created_at")
-    val createdAt: LocalDateTime? = null,
+    var createdAt: LocalDateTime? = null,
 
     @Column(name = "deleted_at")
     val deletedAt: LocalDateTime? = null
-)
+) {
+    companion object {
+        fun of(kakaoUser: KakaoUserResponse): User {
+            return User(
+                kakaoId = kakaoUser.id.toString(),
+                profileImageUrl = kakaoUser.kakaoAccount.profile.profileImageUrl,
+                nickname = kakaoUser.kakaoAccount.profile.nickname
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/zzan/zzan/user/command/infrastructure/UserCommandRepository.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/command/infrastructure/UserCommandRepository.kt
@@ -1,0 +1,6 @@
+package com.zzan.zzan.user.command.infrastructure
+
+import com.zzan.zzan.user.command.domain.User
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserCommandRepository : JpaRepository<User, String>

--- a/src/main/kotlin/com/zzan/zzan/user/query/handler/AuthService.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/query/handler/AuthService.kt
@@ -1,0 +1,19 @@
+package com.zzan.zzan.user.query.handler
+
+import com.zzan.zzan.api.user.dto.LoginResponse
+import com.zzan.zzan.api.user.dto.LoginUrl
+
+interface AuthService {
+    /**
+     * 카카오 로그인 URL을 생성합니다.
+     * @return 카카오 로그인 URL
+     */
+    fun getKakaoLoginUrl(): LoginUrl
+
+    /**
+     * OAuth2.0 콜백을 처리합니다.
+     * @param code 인가 코드
+     * @return 로그인 응답 (액세스 토큰 및 리프레시 토큰 포함)
+     */
+    fun handleKakaoCallback(code: String): LoginResponse
+}

--- a/src/main/kotlin/com/zzan/zzan/user/query/handler/AuthServiceImpl.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/query/handler/AuthServiceImpl.kt
@@ -1,0 +1,42 @@
+package com.zzan.zzan.user.query.handler
+
+import com.zzan.zzan.api.user.dto.LoginResponse
+import com.zzan.zzan.api.user.dto.LoginUrl
+import com.zzan.zzan.common.client.KakaoApiClient
+import com.zzan.zzan.common.util.JwtUtil
+import com.zzan.zzan.user.command.application.UserCommandService
+import com.zzan.zzan.user.command.domain.User
+import org.springframework.stereotype.Service
+
+@Service
+class AuthServiceImpl(
+    private val kakaoApiClient: KakaoApiClient,
+    private val userCommandService: UserCommandService,
+    private val userQueryService: UserQueryService,
+    private val jwtUtil: JwtUtil
+) : AuthService {
+    override fun getKakaoLoginUrl(): LoginUrl {
+        return LoginUrl(kakaoApiClient.getLoginUrl())
+    }
+
+    override fun handleKakaoCallback(code: String): LoginResponse {
+        // 1. 카카오 토큰 받기
+        val kakaoAccessToken = kakaoApiClient.getAccessToken(code)
+
+        // 2. 카카오 사용자 정보 받기
+        val kakaoUser = kakaoApiClient.getUserInfo(kakaoAccessToken)
+
+        // 3. 사용자 저장/조회
+        val userId = userQueryService.findUserIdByKakaoId(kakaoUser.id.toString())
+            ?: userCommandService.createUser(User.of(kakaoUser))
+
+        // 4. JWT 토큰 생성 (액세스 토큰, 리프레시 토큰)
+        val accessToken = jwtUtil.createAccessToken(userId)
+        val refreshToken = jwtUtil.createRefreshToken(userId)
+
+        return LoginResponse(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+        )
+    }
+}

--- a/src/main/kotlin/com/zzan/zzan/user/query/handler/UserQueryService.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/query/handler/UserQueryService.kt
@@ -1,0 +1,5 @@
+package com.zzan.zzan.user.query.handler
+
+interface UserQueryService {
+    fun findUserIdByKakaoId(kakaoId: String): String?
+}

--- a/src/main/kotlin/com/zzan/zzan/user/query/handler/UserQueryServiceImpl.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/query/handler/UserQueryServiceImpl.kt
@@ -1,12 +1,15 @@
 package com.zzan.zzan.user.query.handler
 
 import com.zzan.zzan.user.query.repository.UserQueryRepository
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 
 @Service
 class UserQueryServiceImpl(
     private val userRepository: UserQueryRepository
 ) : UserQueryService {
+
+    @Cacheable("userIdByKakaoId", key = "#kakaoId")
     override fun findUserIdByKakaoId(kakaoId: String): String? {
         return userRepository.findUserIdByKakaoId(kakaoId)
     }

--- a/src/main/kotlin/com/zzan/zzan/user/query/handler/UserQueryServiceImpl.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/query/handler/UserQueryServiceImpl.kt
@@ -1,0 +1,13 @@
+package com.zzan.zzan.user.query.handler
+
+import com.zzan.zzan.user.query.repository.UserQueryRepository
+import org.springframework.stereotype.Service
+
+@Service
+class UserQueryServiceImpl(
+    private val userRepository: UserQueryRepository
+) : UserQueryService {
+    override fun findUserIdByKakaoId(kakaoId: String): String? {
+        return userRepository.findUserIdByKakaoId(kakaoId)
+    }
+}

--- a/src/main/kotlin/com/zzan/zzan/user/query/repository/UserQueryRepository.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/query/repository/UserQueryRepository.kt
@@ -1,0 +1,11 @@
+package com.zzan.zzan.user.query.repository
+
+import com.zzan.zzan.user.command.domain.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface UserQueryRepository : JpaRepository<User, String> {
+
+    @Query("SELECT u.id FROM User u WHERE u.kakaoId = :kakaoId")
+    fun findUserIdByKakaoId(kakaoId: String): String?
+}


### PR DESCRIPTION
## 변경 사항 요약

- 카카오 API를 통한 Oauth 방식의 인증 기능 구현
- Jwt를 사용한 인증 인가 방식을 위한 세팅

## 관련 이슈

<!-- 관련 이슈가 있다면 링크해주세요 -->
- Closes #55 #58 
- Related to #14 

## 테스트

<!-- 기능을 추가했다면, 테스트 방법을 설명해주세요 -->
- [ ] 단위 테스트 추가/업데이트
- [ ] 통합 테스트 확인
- [x] 수동 테스트 완료 : 실제 로그인 후에 사용자 데이터가 데이터베이스에 적재됨을 확인했습니다.
- [ ] 테스트 계획:


## 추가 정보
- Jwt / Kakao 관련 설정값들은 노션 비밀 페이지를 통해 공유했습니다.
- 구체적인 인증 인가 방식은 스프링 시큐리티에 추가해야합니다.