### PR TITLE
feat: 유저 관련 기능 추가 (인증 및 스크랩)

### DIFF
--- a/src/main/kotlin/com/zzan/zzan/api/security/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/security/filter/JwtAuthenticationFilter.kt
@@ -1,28 +1,79 @@
 package com.zzan.zzan.api.security.filter
 
+import com.zzan.zzan.common.util.JwtUtil
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import mu.KLogging
+import mu.KotlinLogging
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
 
 @Component
-class JwtAuthenticationFilter : OncePerRequestFilter() {
-    companion object : KLogging()
+class JwtAuthenticationFilter(
+    private val jwtUtil: JwtUtil,
+) : OncePerRequestFilter() {
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
 
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         filterChain: FilterChain
     ) {
-        // 정적 리소스는 JWT 검증 생략
-        if (request.requestURI == "/favicon.ico") {
-            filterChain.doFilter(request, response)
-            return
+        SecurityContextHolder.clearContext() // 기존 인증정보 제거
+        val token = extractTokenFromRequest(request)
+
+        if (token != null && jwtUtil.validateToken(token) && jwtUtil.isAccessToken(token)) {
+            try {
+                setAuthenticationContext(token, request)
+            } catch (e: Exception) {
+                log.warn { "JWT 인증 처리 중 오류 발생: ${e.message}" }
+                SecurityContextHolder.clearContext()
+            }
         }
 
-        // 실제 JWT 인증 로직이 여기에 들어갈 예정
         filterChain.doFilter(request, response)
     }
+
+    private fun extractTokenFromRequest(request: HttpServletRequest): String? {
+        val bearerToken = request.getHeader("Authorization")
+        return if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            bearerToken.substring(7)
+        } else {
+            null
+        }
+    }
+
+    private fun setAuthenticationContext(token: String, request: HttpServletRequest) {
+        val userId = jwtUtil.getUserIdFromToken(token)
+        val nickname = jwtUtil.getNicknameFromToken(token)
+        val role = jwtUtil.getRoleFromToken(token)
+
+        if (userId != null && role != null) {
+            val authorities = listOf(SimpleGrantedAuthority("ROLE_$role"))
+            
+            val authentication = UsernamePasswordAuthenticationToken(
+                userId, // name
+                null,
+                authorities
+            ).apply {
+                details = JwtUserPrincipal(userId, nickname, role)
+            }
+
+            SecurityContextHolder.getContext().authentication = authentication
+        }
+    }
+
+    /**
+     * JWT에서 추출한 사용자 정보를 담는 Principal 클래스
+     */
+    data class JwtUserPrincipal(
+        val userId: String,
+        val nickname: String?,
+        val role: String
+    )
 }

--- a/src/main/kotlin/com/zzan/zzan/api/user/UserController.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/user/UserController.kt
@@ -1,0 +1,55 @@
+package com.zzan.zzan.api.user
+
+import com.zzan.zzan.api.user.dto.FeedScrapPageResponse
+import com.zzan.zzan.api.user.dto.GetScrapsRequest
+import com.zzan.zzan.api.user.dto.LiquorScrapPageResponse
+import com.zzan.zzan.api.user.dto.ScrapResponse
+import com.zzan.zzan.common.response.ApiResponse
+import com.zzan.zzan.user.command.application.UserCommandService
+import com.zzan.zzan.user.query.handler.UserQueryService
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/user")
+class UserController(
+    private val userQueryService: UserQueryService,
+    private val userCommandService: UserCommandService
+) {
+    @GetMapping("/scraps/feed")
+    fun getFeedScraps(request: GetScrapsRequest): ApiResponse<FeedScrapPageResponse> {
+        val userId = SecurityContextHolder.getContext().authentication.name
+        return ApiResponse.ok(userQueryService.getFeedScraps(request, userId))
+    }
+
+    @GetMapping("/scraps/liquor")
+    fun getLiquorScraps(request: GetScrapsRequest): ApiResponse<LiquorScrapPageResponse> {
+        val userId = SecurityContextHolder.getContext().authentication.name
+        return ApiResponse.ok(userQueryService.getLiquorScraps(request, userId))
+    }
+
+
+    @PostMapping("/scraps/feed")
+    fun createFeedScrap(@RequestParam feedId: String): ApiResponse<ScrapResponse> {
+        val userId = SecurityContextHolder.getContext().authentication.name
+        return ApiResponse.ok(userCommandService.createFeedScrap(userId, feedId))
+    }
+
+    @PostMapping("/scraps/liquor")
+    fun createLiquorScrap(@RequestParam liquorId: String): ApiResponse<ScrapResponse> {
+        val userId = SecurityContextHolder.getContext().authentication.name
+        return ApiResponse.ok(userCommandService.createLiquorScrap(userId, liquorId))
+    }
+
+    @DeleteMapping("/scraps/feed")
+    fun deleteFeedScrap(@RequestParam feedId: String): ApiResponse<ScrapResponse> {
+        val userId = SecurityContextHolder.getContext().authentication.name
+        return ApiResponse.ok(userCommandService.deleteFeedScrap(userId, feedId))
+    }
+
+    @DeleteMapping("/scraps/liquor")
+    fun deleteLiquorScrap(@RequestParam liquorId: String): ApiResponse<ScrapResponse> {
+        val userId = SecurityContextHolder.getContext().authentication.name
+        return ApiResponse.ok(userCommandService.deleteLiquorScrap(userId, liquorId))
+    }
+}

--- a/src/main/kotlin/com/zzan/zzan/api/user/dto/FeedScrapPageResponse.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/user/dto/FeedScrapPageResponse.kt
@@ -1,0 +1,9 @@
+package com.zzan.zzan.api.user.dto
+
+data class FeedScrapPageResponse(
+    val scraps: List<FeedScrapResponse>,
+    val nextCursor: String?,
+    val hasNext: Boolean
+)
+
+

--- a/src/main/kotlin/com/zzan/zzan/api/user/dto/FeedScrapResponse.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/user/dto/FeedScrapResponse.kt
@@ -1,0 +1,10 @@
+package com.zzan.zzan.api.user.dto
+
+data class FeedScrapResponse(
+    val scrapId: String,
+    val feedId: String,
+    val feedImageUrl: String,
+    val placeId: String,
+    val placeName: String,
+    val placeAddress: String,
+)

--- a/src/main/kotlin/com/zzan/zzan/api/user/dto/GetScrapsRequest.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/user/dto/GetScrapsRequest.kt
@@ -1,0 +1,6 @@
+package com.zzan.zzan.api.user.dto
+
+data class GetScrapsRequest(
+    val size: Int = 10,
+    val cursor: String? = null
+)

--- a/src/main/kotlin/com/zzan/zzan/api/user/dto/LiquorScrapPageResponse.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/user/dto/LiquorScrapPageResponse.kt
@@ -1,0 +1,7 @@
+package com.zzan.zzan.api.user.dto
+
+data class LiquorScrapPageResponse(
+    val scraps: List<LiquorScrapResponse>,
+    val nextCursor: String?,
+    val hasNext: Boolean
+)

--- a/src/main/kotlin/com/zzan/zzan/api/user/dto/LiquorScrapResponse.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/user/dto/LiquorScrapResponse.kt
@@ -1,0 +1,10 @@
+package com.zzan.zzan.api.user.dto
+
+data class LiquorScrapResponse(
+    val scrapId: String,
+    val liquorId: String,
+    val liquorName: String,
+    val liquorScore: Double?,
+    val liquorImageUrl: String,
+    val liquorType: String?,
+)

--- a/src/main/kotlin/com/zzan/zzan/api/user/dto/ScrapResponse.kt
+++ b/src/main/kotlin/com/zzan/zzan/api/user/dto/ScrapResponse.kt
@@ -1,0 +1,5 @@
+package com.zzan.zzan.api.user.dto
+
+data class ScrapResponse(
+    val scrapId: String,
+)

--- a/src/main/kotlin/com/zzan/zzan/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/zzan/zzan/common/exception/GlobalExceptionHandler.kt
@@ -11,10 +11,19 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 class GlobalExceptionHandler : KLogging() {
     @ExceptionHandler(CustomException::class)
     fun handleCustomException(e: CustomException): ResponseEntity<ApiResponse<Nothing>> {
-        logger.error("Custom exception occurred: ${e.message} ", e)
+        logger.warn("Custom exception occurred: ${e.message} ", e)
 
         val errorResponse = ApiResponse.error<Nothing>(e.message ?: "오류가 발생했습니다");
         return ResponseEntity.status(e.status)
+            .body(errorResponse)
+    }
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<ApiResponse<Nothing>> {
+        logger.warn("Invalid argument: ${e.message}")
+
+        val errorResponse = ApiResponse.error<Nothing>(e.message ?: "잘못된 요청입니다")
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(errorResponse)
     }
 

--- a/src/main/kotlin/com/zzan/zzan/common/util/JwtUtil.kt
+++ b/src/main/kotlin/com/zzan/zzan/common/util/JwtUtil.kt
@@ -2,6 +2,7 @@ package com.zzan.zzan.common.util
 
 import com.zzan.zzan.common.config.properties.JwtProperties
 import com.zzan.zzan.common.exception.CustomException
+import com.zzan.zzan.user.command.domain.User
 import org.springframework.http.HttpStatus
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm
 import org.springframework.security.oauth2.jwt.*
@@ -20,27 +21,41 @@ class JwtUtil(
         Refresh("refresh")
     }
 
-    private fun createToken(userId: String, validitySeconds: Long, token: Token): String {
+    private fun createToken(claims: Map<String, String?>, validitySeconds: Long, token: Token): String {
         val now = Instant.now()
         val expiry = now.plusSeconds(validitySeconds)
 
-        val claims = JwtClaimsSet.builder()
-            .subject(userId)
+        val jwtClaims = JwtClaimsSet.builder()
+            .subject(claims["userId"] as String)
             .issuedAt(now)
             .expiresAt(expiry)
             .claim("type", token.type)
+            .apply {
+                claims.forEach { (key, value) ->
+                    if (key != "userId") { // subject로 이미 설정됨
+                        claim(key, value)
+                    }
+                }
+            }
             .build()
 
         val headers = JwsHeader.with(MacAlgorithm.HS256).build()
-        return jwtEncoder.encode(JwtEncoderParameters.from(headers, claims)).tokenValue
+        return jwtEncoder.encode(JwtEncoderParameters.from(headers, jwtClaims)).tokenValue
     }
 
-    fun createAccessToken(userId: String): String {
-        return createToken(userId, jwtProperties.accessTokenValiditySeconds, Token.Access)
+    fun createAccessToken(user: User): String {
+        val claims = mapOf(
+            "userId" to user.id,
+            "nickname" to user.nickname,
+            "profileImageUrl" to user.profileImageUrl,
+            "role" to user.role.name
+        )
+        return createToken(claims, jwtProperties.accessTokenValiditySeconds, Token.Access)
     }
 
     fun createRefreshToken(userId: String): String {
-        return createToken(userId, jwtProperties.refreshTokenValiditySeconds, Token.Refresh)
+        val claims = mapOf("userId" to userId)
+        return createToken(claims, jwtProperties.refreshTokenValiditySeconds, Token.Refresh)
     }
 
     fun validateToken(token: String): Boolean {
@@ -52,11 +67,35 @@ class JwtUtil(
         }
     }
 
-    fun getUserIdFromToken(token: String): String {
+    fun getUserIdFromToken(token: String): String? {
         return try {
             jwtDecoder.decode(token).subject
         } catch (e: Exception) {
-            throw CustomException(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다")
+            null
+        }
+    }
+
+    fun getNicknameFromToken(token: String): String? {
+        return try {
+            jwtDecoder.decode(token).getClaimAsString("nickname")
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    fun getProfileImageUrlFromToken(token: String): String? {
+        return try {
+            jwtDecoder.decode(token).getClaimAsString("profileImageUrl")
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    fun getRoleFromToken(token: String): String? {
+        return try {
+            jwtDecoder.decode(token).getClaimAsString("role")
+        } catch (e: Exception) {
+            null
         }
     }
 

--- a/src/main/kotlin/com/zzan/zzan/user/command/application/UserCommandService.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/command/application/UserCommandService.kt
@@ -1,7 +1,16 @@
 package com.zzan.zzan.user.command.application
 
+import com.zzan.zzan.api.user.dto.ScrapResponse
 import com.zzan.zzan.user.command.domain.User
 
 interface UserCommandService {
-    fun createUser(user: User): String
+    fun createUser(user: User): User
+
+    fun createFeedScrap(userId: String, feedId: String): ScrapResponse
+
+    fun createLiquorScrap(userId: String, liquorId: String): ScrapResponse
+
+    fun deleteFeedScrap(userId: String, feedId: String): ScrapResponse
+
+    fun deleteLiquorScrap(userId: String, liquorId: String): ScrapResponse
 }

--- a/src/main/kotlin/com/zzan/zzan/user/command/application/UserCommandServiceImpl.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/command/application/UserCommandServiceImpl.kt
@@ -1,20 +1,63 @@
 package com.zzan.zzan.user.command.application
 
+import com.zzan.zzan.api.user.dto.ScrapResponse
+import com.zzan.zzan.common.exception.CustomException
+import com.zzan.zzan.user.command.domain.FeedScrap
+import com.zzan.zzan.user.command.domain.LiquorScrap
 import com.zzan.zzan.user.command.domain.User
+import com.zzan.zzan.user.command.infrastructure.FeedScrapCommandRepository
+import com.zzan.zzan.user.command.infrastructure.LiquorScrapCommandRepository
 import com.zzan.zzan.user.command.infrastructure.UserCommandRepository
-import org.springframework.cache.annotation.CacheEvict
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 @Transactional
 class UserCommandServiceImpl(
-    private val userRepository: UserCommandRepository
+    private val userRepository: UserCommandRepository,
+    private val feedScrapRepository: FeedScrapCommandRepository,
+    private val liquorScrapRepository: LiquorScrapCommandRepository
 ) : UserCommandService {
 
-    @CacheEvict(value = ["userIdByKakaoId"], key = "#user.kakaoId")
-    override fun createUser(user: User): String {
-        val savedUser = userRepository.save(user)
-        return savedUser.id
+    override fun createUser(user: User): User {
+        return userRepository.save(user)
     }
+
+    override fun createFeedScrap(userId: String, feedId: String): ScrapResponse {
+        if (feedScrapRepository.existsByUserIdAndFeedId(userId, feedId)) {
+            throw CustomException(HttpStatus.CONFLICT, "이미 스크랩된 피드입니다.")
+        }
+
+        return ScrapResponse(
+            feedScrapRepository.save(FeedScrap.of(userId, feedId)).id
+        )
+    }
+
+    override fun createLiquorScrap(userId: String, liquorId: String): ScrapResponse {
+        if (liquorScrapRepository.existsByUserIdAndLiquorId(userId, liquorId)) {
+            throw CustomException(HttpStatus.CONFLICT, "이미 스크랩된 전통주입니다.")
+        }
+
+        return ScrapResponse(
+            liquorScrapRepository.save(LiquorScrap.of(userId, liquorId)).id
+        )
+    }
+
+    override fun deleteFeedScrap(userId: String, feedId: String): ScrapResponse {
+        val feedScrap = feedScrapRepository.findByUserIdAndFeedId(userId, feedId)
+            ?: throw CustomException(HttpStatus.NOT_FOUND, "스크랩이 존재하지 않습니다.")
+
+        feedScrapRepository.delete(feedScrap)
+        return ScrapResponse(feedScrap.id)
+    }
+
+    override fun deleteLiquorScrap(userId: String, liquorId: String): ScrapResponse {
+        val liquorScrap = liquorScrapRepository.findByUserIdAndLiquorId(userId, liquorId)
+            ?: throw CustomException(HttpStatus.NOT_FOUND, "스크랩이 존재하지 않습니다.")
+
+        liquorScrapRepository.delete(liquorScrap)
+        return ScrapResponse(liquorScrap.id)
+    }
+
 }

--- a/src/main/kotlin/com/zzan/zzan/user/command/domain/FeedScrap.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/command/domain/FeedScrap.kt
@@ -18,4 +18,16 @@ class FeedScrap(
 
     @Column(name = "feed_id", length = 26)
     val feedId: String, // 스크랩한 피드 ID
-)
+) {
+    companion object {
+        fun of(userId: String, feedId: String): FeedScrap {
+            require(userId.isNotBlank()) { "사용자 ID는 필수입니다" }
+            require(feedId.isNotBlank()) { "피드 ID는 필수입니다" }
+
+            return FeedScrap(
+                userId = userId,
+                feedId = feedId
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/zzan/zzan/user/command/domain/LiquorScrap.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/command/domain/LiquorScrap.kt
@@ -18,4 +18,16 @@ class LiquorScrap(
 
     @Column(name = "liquor_id", length = 26)
     val liquorId: String, // 스크랩한 전통주 ID
-)
+) {
+    companion object {
+        fun of(userId: String, liquorId: String): LiquorScrap {
+            require(userId.isNotBlank()) { "사용자 ID는 필수입니다" }
+            require(liquorId.isNotBlank()) { "전통주 ID는 필수입니다" }
+            
+            return LiquorScrap(
+                userId = userId,
+                liquorId = liquorId,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/zzan/zzan/user/command/infrastructure/FeedScrapCommandRepository.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/command/infrastructure/FeedScrapCommandRepository.kt
@@ -1,0 +1,9 @@
+package com.zzan.zzan.user.command.infrastructure
+
+import com.zzan.zzan.user.command.domain.FeedScrap
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FeedScrapCommandRepository : JpaRepository<FeedScrap, String> {
+    fun existsByUserIdAndFeedId(userId: String, feedId: String): Boolean
+    fun findByUserIdAndFeedId(userId: String, feedId: String): FeedScrap?
+}

--- a/src/main/kotlin/com/zzan/zzan/user/command/infrastructure/LiquorScrapCommandRepository.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/command/infrastructure/LiquorScrapCommandRepository.kt
@@ -1,0 +1,10 @@
+package com.zzan.zzan.user.command.infrastructure
+
+import com.zzan.zzan.user.command.domain.LiquorScrap
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface LiquorScrapCommandRepository : JpaRepository<LiquorScrap, String> {
+    fun existsByUserIdAndLiquorId(userId: String, liquorId: String): Boolean
+    fun findByUserIdAndLiquorId(userId: String, liquorId: String): LiquorScrap?
+}
+

--- a/src/main/kotlin/com/zzan/zzan/user/query/handler/AuthServiceImpl.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/query/handler/AuthServiceImpl.kt
@@ -27,12 +27,12 @@ class AuthServiceImpl(
         val kakaoUser = kakaoApiClient.getUserInfo(kakaoAccessToken)
 
         // 3. 사용자 저장/조회
-        val userId = userQueryService.findUserIdByKakaoId(kakaoUser.id.toString())
+        val user = userQueryService.findUserByKakaoId(kakaoUser.id.toString())
             ?: userCommandService.createUser(User.of(kakaoUser))
 
         // 4. JWT 토큰 생성 (액세스 토큰, 리프레시 토큰)
-        val accessToken = jwtUtil.createAccessToken(userId)
-        val refreshToken = jwtUtil.createRefreshToken(userId)
+        val accessToken = jwtUtil.createAccessToken(user)
+        val refreshToken = jwtUtil.createRefreshToken(user.id);
 
         return LoginResponse(
             accessToken = accessToken,

--- a/src/main/kotlin/com/zzan/zzan/user/query/handler/UserQueryService.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/query/handler/UserQueryService.kt
@@ -1,5 +1,14 @@
 package com.zzan.zzan.user.query.handler
 
+import com.zzan.zzan.api.user.dto.FeedScrapPageResponse
+import com.zzan.zzan.api.user.dto.GetScrapsRequest
+import com.zzan.zzan.api.user.dto.LiquorScrapPageResponse
+import com.zzan.zzan.user.command.domain.User
+
 interface UserQueryService {
-    fun findUserIdByKakaoId(kakaoId: String): String?
+    fun findUserByKakaoId(kakaoId: String): User?
+
+    fun getFeedScraps(request: GetScrapsRequest, userId: String): FeedScrapPageResponse
+
+    fun getLiquorScraps(request: GetScrapsRequest, userId: String): LiquorScrapPageResponse
 }

--- a/src/main/kotlin/com/zzan/zzan/user/query/handler/UserQueryServiceImpl.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/query/handler/UserQueryServiceImpl.kt
@@ -1,7 +1,12 @@
 package com.zzan.zzan.user.query.handler
 
+import com.zzan.zzan.api.user.dto.FeedScrapPageResponse
+import com.zzan.zzan.api.user.dto.GetScrapsRequest
+import com.zzan.zzan.api.user.dto.LiquorScrapPageResponse
+import com.zzan.zzan.user.command.domain.User
 import com.zzan.zzan.user.query.repository.UserQueryRepository
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 
 @Service
@@ -9,8 +14,42 @@ class UserQueryServiceImpl(
     private val userRepository: UserQueryRepository
 ) : UserQueryService {
 
-    @Cacheable("userIdByKakaoId", key = "#kakaoId")
-    override fun findUserIdByKakaoId(kakaoId: String): String? {
-        return userRepository.findUserIdByKakaoId(kakaoId)
+    @Cacheable("userByKakaoId", key = "#kakaoId")
+    override fun findUserByKakaoId(kakaoId: String): User? {
+        return userRepository.findUserByKakaoId(kakaoId)
+    }
+
+    override fun getFeedScraps(request: GetScrapsRequest, userId: String): FeedScrapPageResponse {
+        val pageable = PageRequest.of(0, request.size + 1)
+        val items = userRepository.findFeedScrapsByUserIdWithCursor(
+            userId = userId,
+            cursor = request.cursor,
+            pageable = pageable
+        )
+
+        val hasNext = items.size > request.size
+
+        return FeedScrapPageResponse(
+            scraps = if (hasNext) items.take(request.size) else items,
+            nextCursor = if (hasNext) items.last().scrapId else null,
+            hasNext = hasNext
+        )
+    }
+
+    override fun getLiquorScraps(request: GetScrapsRequest, userId: String): LiquorScrapPageResponse {
+        val pageable = PageRequest.of(0, request.size + 1)
+        val items = userRepository.findLiquorScrapsByUserIdWithCursor(
+            userId = userId,
+            cursor = request.cursor,
+            pageable = pageable
+        )
+
+        val hasNext = items.size > request.size
+
+        return LiquorScrapPageResponse(
+            scraps = if (hasNext) items.take(request.size) else items,
+            nextCursor = if (hasNext) items.last().scrapId else null,
+            hasNext = hasNext
+        )
     }
 }

--- a/src/main/kotlin/com/zzan/zzan/user/query/repository/UserQueryRepository.kt
+++ b/src/main/kotlin/com/zzan/zzan/user/query/repository/UserQueryRepository.kt
@@ -1,11 +1,52 @@
 package com.zzan.zzan.user.query.repository
 
+import com.zzan.zzan.api.user.dto.FeedScrapResponse
+import com.zzan.zzan.api.user.dto.LiquorScrapResponse
 import com.zzan.zzan.user.command.domain.User
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface UserQueryRepository : JpaRepository<User, String> {
 
-    @Query("SELECT u.id FROM User u WHERE u.kakaoId = :kakaoId")
-    fun findUserIdByKakaoId(kakaoId: String): String?
+    @Query("SELECT u FROM User u WHERE u.kakaoId = :kakaoId")
+    fun findUserByKakaoId(kakaoId: String): User?
+
+    @Query(
+        """
+            SELECT new com.zzan.zzan.api.user.dto.FeedScrapResponse(
+                fs.id, f.id, f.imageUrl, p.id, p.name, p.address
+            )
+            FROM FeedScrap fs 
+            JOIN Feed f ON fs.feedId = f.id
+            JOIN Place p ON f.placeId = p.id
+            WHERE fs.userId = :userId
+            AND (:cursor IS NULL OR fs.id <= :cursor)
+            ORDER BY fs.id DESC
+        """
+    )
+    fun findFeedScrapsByUserIdWithCursor(
+        @Param("userId") userId: String,
+        @Param("cursor") cursor: String?,
+        pageable: Pageable
+    ): List<FeedScrapResponse>
+
+    @Query(
+        """
+            SELECT new com.zzan.zzan.api.user.dto.LiquorScrapResponse(
+                ls.id, l.id, l.name, l.score, l.imageUrl, l.type
+            )
+            FROM LiquorScrap ls 
+            JOIN Liquor l ON ls.liquorId = l.id
+            WHERE ls.userId = :userId
+            AND (:cursor IS NULL OR ls.id <= :cursor)
+            ORDER BY ls.id DESC
+        """
+    )
+    fun findLiquorScrapsByUserIdWithCursor(
+        @Param("userId") userId: String,
+        @Param("cursor") cursor: String?,
+        pageable: Pageable
+    ): List<LiquorScrapResponse>
 }


### PR DESCRIPTION
## 변경 사항 요약
+ 유저 스크랩 관련 Command/Query 서비스, 레포지토리 추가
+ Jwt를 통하여 유저 정보를 Security Context에 저장하는 시큐리티 필터 체인 추가
+ 유저 스크랩 관련 정보를 커서 기반으로 페이지네이션 할 수 있는 조회 로직 추가

## 관련 이슈

<!-- 관련 이슈가 있다면 링크해주세요 -->
- Closes #46 
- Related to #20 #31 

## 테스트

<!-- 기능을 추가했다면, 테스트 방법을 설명해주세요 -->
- [ ] 단위 테스트 추가/업데이트
- [ ] 통합 테스트 확인
- [x] 수동 테스트 완료 : 추가한 기능에 대하여 포스트맨으로 확인
- [ ] 테스트 계획:


## 추가 정보
+ Jwt는 헤더에 Bearer <Token> 방식으로 클라이언트에서 요청을 보낼때 추가해야합니다!
+ Jwt에 포함되는 정보나 시큐리티 컨텍스트에 추가되는 정보는 커밋 내역 확인해주세요.
+ 리베이스를 통해 Conflict 해결했습니다.

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->